### PR TITLE
added cmdline options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "cargo-test-xunit"
-version = "0.0.1"
+version = "0.0.2"
 
 [dependencies]
 sxd-document = "0.2.0"
 regex = "0.2"
+getopts = "0.2"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ cargo install --git https://github.com/DSRCorporation/cargo-test-xunit
 ```
 
 ## Run
-cargo test-xunit
+cargo test-xunit [-outd path/to/output/dir] [-outf filename]
 
-After executing this command in root directory of project will be created file `test-results.xml`
+After executing this command in provided directory (or root directory by default) of project will be created file with the given filename (or `test-results.xml` by default)
 containing `cargo test` output in xunit format.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ cargo install --git https://github.com/DSRCorporation/cargo-test-xunit
 ```
 
 ## Run
+```
 cargo test-xunit [-outd path/to/output/dir] [-outf filename]
+```
 
-After executing this command in provided directory (or root directory by default) of project will be created file with the given filename (or `test-results.xml` by default)
+After executing this command in provided directory (or `root` directory by default) of project will be created file with the given filename (or `test-results.xml` by default)
 containing `cargo test` output in xunit format.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate sxd_document;
+extern crate getopts;
 
 mod element;
 mod parser;
@@ -7,9 +8,39 @@ use std::fs::File;
 use std::process::Command;
 use sxd_document::Package;
 use sxd_document::writer::format_document;
+use getopts::Options;
+use std::env;
+use std::fs::DirBuilder;
 
 
 fn main() {
+
+    // Read args and prepare vars
+    let args: Vec<String> = env::args().collect();
+    let program = args[0].clone();
+
+    let mut opts = Options::new();
+    opts.optopt("", "outd", "set output directory (defaults to current dir)", "PATH");
+    opts.optopt("", "outf", "set output file name (defaults to test-results.xml)", "NAME");
+    opts.optflag("h", "help", "print this help menu");
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => { m }
+        Err(f) => { panic!(f.to_string()) }
+    };
+    if matches.opt_present("h") {
+        print_usage(&program, opts);
+        return;
+    }
+    let outd_arg = matches.opt_str("outd");
+    let outd_path = outd_arg.unwrap_or(".".to_owned());
+
+    let outf_arg = matches.opt_str("outf");
+    let outf_name = outf_arg.unwrap_or("test-results.xml".to_owned());
+
+    let mut filepath: String = "".to_owned();
+    filepath.push_str(&outd_path);
+    filepath.push_str("/");
+    filepath.push_str(&outf_name);
 
     println!("Running tests");
 
@@ -35,13 +66,21 @@ fn main() {
 
     println!("Writing report");
 
-    let mut f = File::create("test-results.xml").unwrap();
+    DirBuilder::new()
+        .recursive(true)
+        .create(outd_path).unwrap();
+    let mut f = File::create(&filepath).unwrap();
 
     format_document(&document, &mut f)
         .ok()
         .expect("unable to output XML");
 
     println!("Writing report -> done");
+}
+
+fn print_usage(program: &str, opts: Options) {
+    let brief = format!("Usage: {} FILE [options]", program);
+    print!("{}", opts.usage(&brief));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I'm not a rust developer, so the code most probably needs some refactoring, but I need these cmdline options so I've added them for my usage. And then decided to create PR offcially

Optional cmdline args:
-h, --h : prints usage
--outd : path to output directory
--outf : output filename

Cheers